### PR TITLE
PAN-1703- Pokemon Sample Integration (Part 2)

### DIFF
--- a/POKEMON_OF_THE_DAY/PANDIUM.yaml
+++ b/POKEMON_OF_THE_DAY/PANDIUM.yaml
@@ -2,3 +2,40 @@ version: 0.4
 base: node:20.9.0
 build: npm install --production && npm i --save-dev @types/node && npm run build
 run: node .
+configs:
+  schema:
+    required:
+      - pokemon_type
+      - slack_user
+    definitions:
+      slack_users:
+        type: number
+        oneOf:
+          - title: Placeholder
+            const: placeholder
+      pokemon_types:
+        enum:
+          - placeholder  
+    properties:
+      pokemon_type:
+        type: string
+        $ref: '#/definitions/pokemon_types'
+      slack_user:
+        type: string
+        $ref: '#/definitions/slack_users'
+    type: object 
+  uischema:
+    elements:
+    - type: Section
+      label: Configure Pokémon of the Day
+      hintText: Select which type of Pokémon you would like to learn about, and the Slack User who will receive the Pokémon of the day message.
+      elements:
+
+      - label: Pokémon Type
+        scope: '#/properties/pokemon_type'
+        type: Control
+
+      - label: Slack User
+        scope: '#/properties/slack_user'
+        type: Control
+    type: VerticalLayout

--- a/POKEMON_OF_THE_DAY/README.md
+++ b/POKEMON_OF_THE_DAY/README.md
@@ -14,7 +14,10 @@ Pokémon Of The Day is a simple integration built to be run on Pandium.  This is
 
 ## Next Steps in learning to write Pandium integrations
 
-For those who want to hone their integration writing skills after completing this integration, consider what additions would be needed to handle the following situations:
-- The user has not selected a Slack user or Pokémon Type.
-- There are no more Pokémon of the selected type which have not yet been the Pokémon of the day.
-- The user has switched back and forth between init and normal modes, and context needs to be maintained.
+For those who want to hone their integration writing skills after completing this integration, 
+- Consider what additions would be needed to handle the following situations:
+  - The user has not selected a Slack user or Pokémon Type.
+  - There are no more Pokémon of the selected type which have not yet been the Pokémon of the day.
+  - The user has switched back and forth between init and normal modes, and context needs to be maintained.
+
+- Add a Logger class (either from a library or writing a cusom one) which handles all the logging.

--- a/POKEMON_OF_THE_DAY/README.md
+++ b/POKEMON_OF_THE_DAY/README.md
@@ -3,10 +3,18 @@
 
 ## Intro
 
-Pokémon Of The Day is a simple integration built to be run on Pandium.  This is the result of Pandium's Pokémon of the Day tutorial: Part 1
+Pokémon Of The Day is a simple integration built to be run on Pandium.  This is the result of Pandium's Pokémon of the Day tutorial: Part 2.
 
 ## Integration Features:
 
-- On a normal run it will identify & fetch the Pokémon of the day and then send a Slack message about it to the Academy's Pokémon trainers.
+- On a normal run it will identify & fetch the Pokémon of the day and then send a Slack message about it. 
+- The user can choose which type of Pokémon they would like to get messages about: It will read the different types of Pokémon available from the PokéAPI to dynamically populate the options for that config.  This will ensure the list is kept up to date even if a new kind of Pokémon is added.
+- The user can choose who will receive the Slack Message about the Pokémon of the day:  It will read the different users available from the Slack workspace to dynamically populate the options for that config.  
 - The integration will not send a message about the same Pokémon twice.
 
+## Next Steps in learning to write Pandium integrations
+
+For those who want to hone their integration writing skills after completing this integration, consider what additions would be needed to handle the following situations:
+- The user has not selected a Slack user or Pokémon Type.
+- There are no more Pokémon of the selected type which have not yet been the Pokémon of the day.
+- The user has switched back and forth between init and normal modes, and context needs to be maintained.

--- a/POKEMON_OF_THE_DAY/env.default
+++ b/POKEMON_OF_THE_DAY/env.default
@@ -5,6 +5,12 @@
 # Credentials provided when App is created for a particular Slack Workspace
 PAN_SEC_SLACK_OAUTH_ACCESS_TOKEN = xoxb...
 
+# The type Pokémon the user has selected to learn about.
+PAN_CFG_POKEMON_TYPE = rock
+
+# Slack Member ID who will receive the Pokémon of the day message.
+PAN_CFG_SLACK_USER=
+
 # init or normal
 PAN_CTX_RUN_MODE = normal
 

--- a/POKEMON_OF_THE_DAY/src/index.ts
+++ b/POKEMON_OF_THE_DAY/src/index.ts
@@ -5,6 +5,7 @@ import { WebClient } from "@slack/web-api";
 import Pokedex from "pokedex-promise-v2";
 import { Config, Secret, Context } from "./lib.js";
 import { pokemonSync } from "./processLogic/pokemonSync.js";
+import { initSync } from "./processLogic/initSync.js";
 
 const run = async () => {
   const context = new Context();
@@ -25,8 +26,16 @@ const run = async () => {
   const slackClient = new WebClient(secrets.slack_oauth_access_token);
 
   if (context.run_mode === "normal") {
-    const standardOut = await pokemonSync(pokeClient, slackClient, context);
+    const standardOut = await pokemonSync(
+      pokeClient,
+      slackClient,
+      context,
+      config
+    );
     console.log(JSON.stringify(standardOut));
+  } else {
+    const initStandardOut = await initSync(pokeClient, slackClient);
+    console.log(JSON.stringify(initStandardOut));
   }
 };
 

--- a/POKEMON_OF_THE_DAY/src/models.ts
+++ b/POKEMON_OF_THE_DAY/src/models.ts
@@ -1,0 +1,4 @@
+export interface OneOfOption {
+  const: string;
+  title: string;
+}

--- a/POKEMON_OF_THE_DAY/src/processLogic/initSync.ts
+++ b/POKEMON_OF_THE_DAY/src/processLogic/initSync.ts
@@ -1,0 +1,49 @@
+import { WebClient } from "@slack/web-api";
+import Pokedex from "pokedex-promise-v2";
+import { OneOfOption } from "../models.js";
+
+/* 
+This flow fetches slack_users and pokemon_types and prints them to the standard out. 
+This allows the Pandium platform to use them to populate options for the pokemon_type 
+and slack_user dynamic configs.
+*/
+export const initSync = async (pokeClient: Pokedex, slackClient: WebClient) => {
+  console.error("------------------------INIT SYNC------------------------");
+
+  let pokemonTypes: string[] = [];
+  try {
+    const { results: types } = await pokeClient.getTypesList();
+    pokemonTypes = types.map((type) => type.name);
+  } catch (error) {
+    console.error(error);
+  }
+
+  const slackUsers: OneOfOption[] = [];
+  try {
+    const response = await slackClient.users.list();
+
+    response.members?.forEach((user) => {
+      if (
+        user.deleted ||
+        user.is_bot ||
+        !user.is_email_confirmed ||
+        !user.id ||
+        !user.name
+      )
+        return;
+
+      slackUsers.push({
+        const: user.id,
+        title: user.name,
+      });
+    });
+  } catch (error) {
+    console.error(error);
+    return {};
+  }
+
+  return {
+    slack_users: slackUsers,
+    pokemon_types: pokemonTypes,
+  };
+};

--- a/POKEMON_OF_THE_DAY/src/processLogic/pokemonSync.ts
+++ b/POKEMON_OF_THE_DAY/src/processLogic/pokemonSync.ts
@@ -1,19 +1,24 @@
 import Pokedex from "pokedex-promise-v2";
 import { WebClient } from "@slack/web-api";
 import { pokemonToSlackMessage } from "../transformations.js";
-import { Context } from "../lib.js";
+import { Context, Config } from "../lib.js";
 
 /* 
 This flow identifies the Pokémon of the day and sends a Slack message about
-it to the users in slackMemberIds.
+it to the user selected in the config.
 */
 
 export const pokemonSync = async (
   pokeClient: Pokedex,
   slackClient: WebClient,
-  context: Context
+  context: Context,
+  config: Config
 ) => {
   console.error("------------------------POKEMON SYNC------------------------");
+
+  // Fetch the Pokémon of the type selected by the user in tenant settings.
+  const pokemonType = await pokeClient.getTypeByName(config.pokemon_type);
+  const pokemonOptions = pokemonType.pokemon;
 
   // Access the previous Pokémon of the day from context
   let lastPokemonId = 0;
@@ -21,17 +26,25 @@ export const pokemonSync = async (
     const lastStdOut = JSON.parse(context.last_successful_run_std_out);
     lastPokemonId = Number(lastStdOut.last_pokemon_id) || 0;
   }
-  // Get the ID of the first Pokémon which has not already been the Pokémon of the day
-  const nextPokemonId = lastPokemonId + 1;
+
+  // Find the first Pokémon of the selected type which has not already been the Pokémon of the day
+  let nextPokemonId: string | undefined;
+  for (const pokemon of pokemonOptions) {
+    const pokemonId = Number(pokemon.pokemon.url.split("/").slice(-2, -1)[0]);
+    if (pokemonId <= lastPokemonId) continue;
+    nextPokemonId = String(pokemonId);
+    break;
+  }
+  if (!nextPokemonId) return { last_pokemon_id: lastPokemonId };
+
   const pokemonOfTheDay = await pokeClient.getPokemonByName(nextPokemonId);
 
-  const slackMemberIds = ["<YOUR-SLACK-MEMBER-ID>"];
-
-  // Create a Slack Message Payload and send it to each of the slackMemberIds
-  for (const slackID of slackMemberIds) {
-    const slackMessage = pokemonToSlackMessage(pokemonOfTheDay, slackID);
-    await slackClient.chat.postMessage(slackMessage);
-  }
+  // Create and send the Slack Message about the Pokémon of the Day.
+  const slackMessage = pokemonToSlackMessage(
+    pokemonOfTheDay,
+    config.slack_user
+  );
+  await slackClient.chat.postMessage(slackMessage);
 
   return { last_pokemon_id: nextPokemonId };
 };


### PR DESCRIPTION
[PAN-1703](https://greenwoodtech.atlassian.net/browse/PAN-1703?atlOrigin=eyJpIjoiYjU0NmE1NDM3ODM2NDgxNTkyNmMyN2U1YjJkNTUzZmUiLCJwIjoiaiJ9)

Changes:
This is the result of following part 2 of the pokemon tutorial
- Add the configs to the .yaml and env.default
- Since the configs are dynamic we add an init sync to populate their options.
- Alter the pokemonSync to use the new configs.

[PAN-1703]: https://greenwoodtech.atlassian.net/browse/PAN-1703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ